### PR TITLE
remove shared-modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "shared-modules"]
-	path = shared-modules
-	url = https://github.com/flathub/shared-modules.git

--- a/io.github.Qalculate.yaml
+++ b/io.github.Qalculate.yaml
@@ -22,8 +22,6 @@ cleanup:
   - /share/man
   - '*.la'
 modules:
-  - shared-modules/intltool/intltool-0.51.json
-
   - name: wxwidgets
     config-opts:
       - --with-libjpeg


### PR DESCRIPTION
`intltool` is not required anymore and can be removed